### PR TITLE
Freshen dependencies and better starting of development env.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,5 @@
-redis: redis-cli ping 2> /dev/null || redis-server /usr/local/etc/redis.conf
+redis:    redis-cli ping 2> /dev/null || redis-server /usr/local/etc/redis.conf
+devices:  ./node_modules/.bin/forever -w devices.js
+rules:    ./node_modules/.bin/forever -w rules.js
+home:     ./node_modules/.bin/forever -w home.js
+hookshot: ./node_modules/.bin/forever -w hookshot.js

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+redis: redis-cli ping 2> /dev/null || redis-server /usr/local/etc/redis.conf

--- a/devices.js
+++ b/devices.js
@@ -168,7 +168,7 @@ function onAction( event, done ) {
 function ready () {
 	'use strict';
 
-	//console.log( 'device.js ready', devices );
+	console.log( 'device.js ready', devices );
 	events.process( 'action', onAction );
 
 	//console.log( deviceSelector( 'room:Kitchen' ));

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "es6-promise": "^3.0.2",
     "forecast": "^0.2.1",
     "hookshot": "^0.1.0",
-    "kue": "^0.8.9",
+    "kue": "^0.9.6",
     "netatmo": "^1.1.1",
     "node-fetch": "^1.3.2",
     "node-hue-api": "^0.2.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "colr": "^1.2.1",
     "cron": "^1.0.5",
-    "es6-promise": "^2.0.0",
+    "es6-promise": "^3.0.2",
     "forecast": "^0.2.1",
     "hookshot": "^0.1.0",
     "kue": "^0.8.9",

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
     "suncalc": "~1.6.0",
     "verisure-api": "git://github.com/suhajdab/verisure-api.git#master",
     "wemore": "0.0.1"
+  },
+  "devDependencies": {
+    "foreman": "^1.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,8 +32,5 @@
     "suncalc": "~1.6.0",
     "verisure-api": "git://github.com/suhajdab/verisure-api.git#master",
     "wemore": "0.0.1"
-  },
-  "devDependencies": {
-    "grunt": "^0.4.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node-hue-api": "^0.2.3",
     "node-rest-client": "^1.4.1",
     "node-uuid": "^1.4.1",
-    "object-assign": "^1.0.0",
+    "object-assign": "^4.0.1",
     "redis": "^0.12.1",
     "restify": "^2.8.3",
     "spark": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "home automation in node",
   "main": "home.js",
   "scripts": {
-    "start": "forever -w devices.js && forever -w rules.js && forever -w hookshot.js",
+    "start": "./node_modules/.bin/nf start",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -34,6 +34,7 @@
     "wemore": "0.0.1"
   },
   "devDependencies": {
-    "foreman": "^1.4.1"
+    "foreman": "^1.4.1",
+    "forever": "^0.15.1"
   }
 }


### PR DESCRIPTION
See individual commits for details.

1. Update som dependencies. I didn't dare to update `wemore`, `redis`, `node-hue-api` since I didn't know how to test them. Run `npm outdated` to see the current status and update them.
2. Use `node-foreman` to start up the environment. I understand that the plan forward is to let `home.js` run everything, but as that is not the case today, fix todays problem, and build a better future tomorrow.

Opinions? Something I have misunderstood? You have other plans? Try it out locally and see how it looks.

![](https://dl.dropboxusercontent.com/s/ngwsya0xcl5p9xp/2015-11-01%20at%2023.00.png?dl=0)